### PR TITLE
fix: properly center version badge and other text-center elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,10 @@
             }
         }
 
+        .text-center {
+            text-align: center;
+        }
+
         .version-badge {
             display: inline-flex;
             align-items: center;


### PR DESCRIPTION
This update fixes alignment issues by ensuring all .text-center elements, including the version badge, are correctly centered.